### PR TITLE
Add instructions to use the dark mode with zsh-autosuggestions

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,15 @@ config: {
 ```
 <img src="assets/preview-dark.jpg?raw=true" alt="Hypest Screenshot" width="600" />
 
+**Note:** if you're using `zsh` shell with `zsh-autosuggestions` and Hypest theme 
+is on `darkmode`, you may need to change the property `ZSH_AUTOSUGGEST_HIGHLIGHT_STYLE`
+at `.zshrc` file, like the following example:
+
+```js
+ZSH_AUTOSUGGEST_HIGHLIGHT_STYLE="fg=243";
+// Where `243` is a color number from 256-color palette (default is `8`)
+```
+
 ### Vibrancy
 Set `vibrancy` to `false` to disable the window vibrancy effect in either theme.
 ```js


### PR DESCRIPTION
The default text color of zsh-autosuggestions is almost the same of Hypest background color in `darkmode`, so I had to change the **ZSH_AUTOSUGGEST_HIGHLIGHT_STYLE** property on my zsh configuration file to see the suggestions on my terminal. To help others to solve this problem I added a **Note** in the end of Dark Mode section.

**Before change the ZSH_AUTOSUGGEST_HIGHLIGHT_STYLE property**
![Screen Shot 2020-07-05 at 00 41 56](https://user-images.githubusercontent.com/17644982/86525106-39d74f00-be59-11ea-895c-d73aa30d7b76.png)

**After**
![Screen Shot 2020-07-05 at 00 42 30](https://user-images.githubusercontent.com/17644982/86525114-4f4c7900-be59-11ea-98c8-ef1173ab278b.png)
